### PR TITLE
Fix API structure for ASF V2.1.5.5+

### DIFF
--- a/ASFui/API.cs
+++ b/ASFui/API.cs
@@ -61,7 +61,7 @@ namespace ASFui
                     result.Append(@"    ⟐ Current Farming: Nothing" + Environment.NewLine);
                 }
 
-                result.Append(@"    ⟐ Manual: " + _data.Bot[bot].CardsFarmer.ManualMode + Environment.NewLine);
+                result.Append(@"    ⟐ Paused: " + _data.Bot[bot].CardsFarmer.Paused + Environment.NewLine);
 
                 result.Append(Environment.NewLine);
             }

--- a/ASFui/Bot.cs
+++ b/ASFui/Bot.cs
@@ -30,8 +30,8 @@ namespace ASFui
             [JsonProperty("CurrentGamesFarming")]
             public HashSet<Game> CurrentGamesFarming { get; set; }
 
-            [JsonProperty("ManualMode")]
-            public bool ManualMode { get; set; }
+            [JsonProperty("Paused")]
+            public bool Paused { get; set; }
         }
 
         public class Game


### PR DESCRIPTION
Merge whenever you will want to support ASF V2.1.5.5+

Change happened due to upcoming family sharing support, specifically in **[this](https://github.com/JustArchi/ArchiSteamFarm/commit/629c40b807fc0f60c43a38235c4d2092a995881e)** commit. **[API](https://github.com/JustArchi/ArchiSteamFarm/wiki/API#cardsfarmer)** is already updated to cover this change. The purpose of the field is very similar to `ManualMode`, but as it covers more things now, rename was needed.
