### PR TITLE
Fixing WCF connection after ASF V2.1.7.6

### DIFF
--- a/ASFui/ASFui.csproj
+++ b/ASFui/ASFui.csproj
@@ -194,6 +194,17 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
   </Target>
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent Condition=" '$(OS)' != 'Unix' AND '$(ConfigurationName)' == 'Release' ">
+      "$(SolutionDir)..\ArchiSteamFarm\tools\ILRepack\ILRepack.exe" /ndebug /internalize /parallel /targetplatform:v4 /wildcards /out:"$(SolutionDir)../ArchiSteamFarm/out/ASFui.exe" "$(TargetDir)$(TargetName).exe" "$(TargetDir)*.dll"
+      del "$(SolutionDir)\..\ArchiSteamFarm\out\ASFui.exe.config"
+	  copy "$(TargetDir)$(TargetName).exe" "$(SolutionDir)\..\ArchiSteamFarm\out\$(TargetName).exe"
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ASFui/Util.cs
+++ b/ASFui/Util.cs
@@ -14,7 +14,7 @@ namespace ASFui
 {
     internal static class Util
     {
-        private static readonly BasicHttpBinding Binding = new BasicHttpBinding {SendTimeout = new TimeSpan(0, 30, 0)};
+        private static readonly NetTcpBinding Binding = new NetTcpBinding { SendTimeout = new TimeSpan(0, 30, 0)};
 
         public static bool CheckBinary()
         {
@@ -49,10 +49,10 @@ namespace ASFui
             var json =
                 JObject.Parse(
                     File.ReadAllText(Path.GetDirectoryName(Settings.Default.ASFBinary) + @"/config/ASF.json"));
-            var hostname = json["WCFHostname"].ToString();
+            var hostname = json["WCFHost"].ToString();
             var port = json["WCFPort"].ToString();
 
-            return "http://" + hostname + ":" + port + "/ASF";
+            return "net.tcp://" + hostname + ":" + port + "/ASF";
         }
 
         public static bool CheckIfAsfIsRunning()


### PR DESCRIPTION
Hi,
the three lines in Util.cs fix the WCF connection, after archi switched to net.tcp.

The changes in the csproj are to let it be packed after building inside the "out" folder of ASF (if both repos are in the same directory). Did that for me, but can't find, where to execlude a file from the Pull request and I'm to lazy to create a new branch ;-> That makes the build test fail ^^

Regards.