### PR TITLE
fixed ASF.json check to ignore on error

### DIFF
--- a/ASFui/ASFProcess.cs
+++ b/ASFui/ASFProcess.cs
@@ -87,16 +87,16 @@ namespace ASFui
                 var Password = new Password(ASF, e.Data);
                 Password.ShowDialog();
             }
-            Match match = Regex.Match(e.Data, @".*Key: (.*) \| Status: (OK|DuplicatedKey|InvalidKey|AlreadyOwned|OnCooldown)");
+            Match match = Regex.Match(e.Data, @".*Key: (.*) \| Status: (OK|DuplicatedKey|InvalidKey|AlreadyOwned|OnCooldown|NoDetail|DuplicateActivationCode|BadActivationCode|AlreadyPurchased|RateLimited)");
             if (match.Success)
             {
                 string key = match.Groups[1].ToString();
                 string type = match.Groups[2].ToString();
-                if (("OK".Equals(type) && Properties.Settings.Default.ClearOk) ||
-                    ("DuplicatedKey".Equals(type) && Properties.Settings.Default.ClearDuplicated) ||
-                    ("InvalidKey".Equals(type) && Properties.Settings.Default.ClearInvalid) ||
-                    ("AlreadyOwned".Equals(type) && Properties.Settings.Default.ClearOwned) ||
-                    ("OnCooldown".Equals(type) && Properties.Settings.Default.ClearCooldown)) {
+                if ((("OK".Equals(type) || "NoDetail".Equals(type)) && Properties.Settings.Default.ClearOk) ||
+                    (("DuplicatedKey".Equals(type) || "DuplicateActivationCode".Equals(type)) && Properties.Settings.Default.ClearDuplicated) ||
+                    (("InvalidKey".Equals(type) || "BadActivationCode".Equals(type)) && Properties.Settings.Default.ClearInvalid) ||
+                    (("AlreadyOwned".Equals(type) || "AlreadyPurchased".Equals(type)) && Properties.Settings.Default.ClearOwned) ||
+                    (("OnCooldown".Equals(type) || "RateLimited".Equals(type)) && Properties.Settings.Default.ClearCooldown)) {
                     _asf.tbInput.Invoke(new MethodInvoker(() => {
                         _asf.tbInput.Text = Regex.Replace(_asf.tbInput.Text.Replace(key, ""), @"\s+", Environment.NewLine);
                         if (_asf.tbInput.Text.Length < 2) // remove the last newline, if we removed all keys.

--- a/ASFui/ASFProcess.cs
+++ b/ASFui/ASFProcess.cs
@@ -29,21 +29,25 @@ namespace ASFui
         }
 
         private void init() {
-            var ASFInfo = new ProcessStartInfo() {
-                Arguments = "--server",
-                CreateNoWindow = true,
-                Domain = "",
-                FileName = Properties.Settings.Default.ASFBinary,
-                LoadUserProfile = false,
-                Password = null,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
-                StandardErrorEncoding = Encoding.UTF8,
-                StandardOutputEncoding = Encoding.UTF8,
-                UseShellExecute = false,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
+			var ASFInfo = new ProcessStartInfo() {
+				Arguments = "--server",
+				CreateNoWindow = true,
+				Domain = "",
+				FileName = Properties.Settings.Default.ASFBinary,
+				LoadUserProfile = false,
+				Password = null,
+				RedirectStandardError = true,
+				RedirectStandardInput = true,
+				RedirectStandardOutput = true,
+				StandardErrorEncoding = Encoding.UTF8,
+				StandardOutputEncoding = Encoding.UTF8,
+				UseShellExecute = false,
+				WindowStyle = ProcessWindowStyle.Hidden
+			};
+			if (Properties.Settings.Default.ASFBinary.EndsWith("dll")) {
+				ASFInfo.Arguments = Properties.Settings.Default.ASFBinary + " --server";
+				ASFInfo.FileName = "dotnet";
+			}
 
             ASF.StartInfo = ASFInfo;
             ASF.OutputDataReceived += OutputHandler;

--- a/ASFui/ASFui.cs
+++ b/ASFui/ASFui.cs
@@ -127,7 +127,10 @@ namespace ASFui
             if ("Couldn't find any bot named ASF!".Equals(status))
                 status = Util.SendCommand("statusall"); // keep backwardscompatibility
 
-            var matches = Regex.Matches(status, @"Bot (.*) is");
+            var matches = Regex.Matches(status, @"<(.*)> Bot is");
+            if(matches.Count==0)
+                matches = Regex.Matches(status, @"Bot (.*) is");
+
             cbBotList.Invoke(new MethodInvoker(() =>
             {
                 foreach (Match m in matches)

--- a/ASFui/ASFui.cs
+++ b/ASFui/ASFui.cs
@@ -203,15 +203,15 @@ namespace ASFui
                             asfConfig.CurrentCulture = "en";
                             msg = true;
                         }
-                        if (asfConfig.AutoRestart.Value) {
+                        if (asfConfig.AutoRestart==null || asfConfig.AutoRestart.Value) {
                             message = message + "AutoRestart (ASFui always restart ASF): is: " + asfConfig.AutoRestart + ", will be: false" + Environment.NewLine;
-                            asfConfig.AutoRestart.Value = false;
+                            asfConfig.AutoRestart = false;
                             msg = true;
                         }
-                        if (0 == asfConfig.SteamOwnerID.Value) {
+                        if (asfConfig.SteamOwnerID ==null|| 0 == asfConfig.SteamOwnerID.Value) {
                             // this is not yet confirmed by archi to be allowed, otherwise message here "change manually" and exit.
                             message = message + "SteamOwnerID (CHANGE THIS TO YOUR MAIN ACCOUNT ASAP!): is: " + asfConfig.SteamOwnerID + ", will be: " + ulong.MaxValue + Environment.NewLine;
-                            asfConfig.SteamOwnerID.Value = ulong.MaxValue;
+                            asfConfig.SteamOwnerID = ulong.MaxValue;
                             msg = true;
                         }
                         if (msg) {

--- a/ASFui/ASFui.cs
+++ b/ASFui/ASFui.cs
@@ -185,50 +185,52 @@ namespace ASFui
         {
             if (Properties.Settings.Default.IsLocal)
             {
-                string binary = Settings.Default.ASFBinary;
-                int index = binary.LastIndexOf('/');
-                if (index == -1) {
-                    index = binary.LastIndexOf('\\');
-                }
-                if (index != -1) {
-                    string message = "The following Parameter will be changed automatically. Abort to change them manually." + Environment.NewLine;
-                    // not sure about if I should use \\ or /
-                    string asfJson = binary.Substring(0, index) + "\\config\\ASF.json";
-                    dynamic asfConfig= JsonConvert.DeserializeObject(File.ReadAllText(asfJson));
-                    string culture = asfConfig.CurrentCulture;
-                    bool msg = false;
-                    if (!"en".Equals(culture)) {
-                        message=message+ "Language (CurrentCulture): is: "+ asfConfig.CurrentCulture +", will be: \"en\""+ Environment.NewLine;
-                        asfConfig.CurrentCulture = "en";
-                        msg = true;
+                try {
+                    string binary = Settings.Default.ASFBinary;
+                    int index = binary.LastIndexOf('/');
+                    if (index == -1) {
+                        index = binary.LastIndexOf('\\');
                     }
-                    if (asfConfig.AutoRestart.Value) {
-                        message = message + "AutoRestart (ASFui always restart ASF): is: " + asfConfig.AutoRestart + ", will be: false" + Environment.NewLine;
-                        asfConfig.AutoRestart.Value = false;
-                        msg = true;
-                    }
-                    if (0 == asfConfig.SteamOwnerID.Value) {
-                        // this is not yet confirmed by archi to be allowed, otherwise message here "change manually" and exit.
-                        message = message + "SteamOwnerID (CHANGE THIS TO YOUR MAIN ACCOUNT ASAP!): is: " + asfConfig.SteamOwnerID + ", will be: " + ulong.MaxValue + Environment.NewLine;
-                        asfConfig.SteamOwnerID.Value = ulong.MaxValue;
-                        msg = true;
-                    }
-                    if (msg) {
-                        var result = MessageBox.Show(message, @"Config needs to be changed.", MessageBoxButtons.OKCancel, MessageBoxIcon.Error);
-                        if (result == System.Windows.Forms.DialogResult.OK) {
-                            try {
-                                File.WriteAllText(asfJson, JsonConvert.SerializeObject(asfConfig, Formatting.Indented));
-                            } catch (Exception ex) {
-                                MessageBox.Show("Error writing changes. Change manually and restart." + Environment.NewLine + "Exiting....");
+                    if (index != -1) {
+                        string message = "The following Parameter will be changed automatically. Abort to change them manually." + Environment.NewLine;
+                        // not sure about if I should use \\ or /
+                        string asfJson = binary.Substring(0, index) + "\\config\\ASF.json";
+                        dynamic asfConfig = JsonConvert.DeserializeObject(File.ReadAllText(asfJson));
+                        string culture = asfConfig.CurrentCulture;
+                        bool msg = false;
+                        if (!"en".Equals(culture)) {
+                            message = message + "Language (CurrentCulture): is: " + asfConfig.CurrentCulture + ", will be: \"en\"" + Environment.NewLine;
+                            asfConfig.CurrentCulture = "en";
+                            msg = true;
+                        }
+                        if (asfConfig.AutoRestart.Value) {
+                            message = message + "AutoRestart (ASFui always restart ASF): is: " + asfConfig.AutoRestart + ", will be: false" + Environment.NewLine;
+                            asfConfig.AutoRestart.Value = false;
+                            msg = true;
+                        }
+                        if (0 == asfConfig.SteamOwnerID.Value) {
+                            // this is not yet confirmed by archi to be allowed, otherwise message here "change manually" and exit.
+                            message = message + "SteamOwnerID (CHANGE THIS TO YOUR MAIN ACCOUNT ASAP!): is: " + asfConfig.SteamOwnerID + ", will be: " + ulong.MaxValue + Environment.NewLine;
+                            asfConfig.SteamOwnerID.Value = ulong.MaxValue;
+                            msg = true;
+                        }
+                        if (msg) {
+                            var result = MessageBox.Show(message, @"Config needs to be changed.", MessageBoxButtons.OKCancel, MessageBoxIcon.Error);
+                            if (result == System.Windows.Forms.DialogResult.OK) {
+                                try {
+                                    File.WriteAllText(asfJson, JsonConvert.SerializeObject(asfConfig, Formatting.Indented));
+                                } catch (Exception ex) {
+                                    MessageBox.Show("Error writing changes. Change manually and restart." + Environment.NewLine + "Exiting....");
+                                    Application.Exit();
+                                    return;
+                                }
+                            } else {
                                 Application.Exit();
                                 return;
                             }
-                        } else {
-                            Application.Exit();
-                            return;
                         }
                     }
-                }
+                } catch{ /*ignore */}
 
                 _asf = new ASFProcess(this, rtbOutput);
                 _asf.Start();

--- a/ASFui/ASFui.cs
+++ b/ASFui/ASFui.cs
@@ -123,7 +123,10 @@ namespace ASFui
         {
             cbBotList.Invoke(new MethodInvoker(() => cbBotList.Items.Clear()));
 
-            var status = Util.SendCommand("statusall");
+            var status = Util.SendCommand("status ASF");
+            if ("Couldn't find any bot named ASF!".Equals(status))
+                status = Util.SendCommand("statusall"); // keep backwardscompatibility
+
             var matches = Regex.Matches(status, @"Bot (.*) is");
             cbBotList.Invoke(new MethodInvoker(() =>
             {
@@ -315,7 +318,9 @@ namespace ASFui
         {
             Task.Run(() =>
             {
-                sendCommand("lootall");
+                var status = sendCommand("loot ASF");
+                if ("Couldn't find any bot named ASF!".Equals(status))
+                    status = sendCommand("lootall"); // keep backwardscompatibility
             });
         }
 
@@ -375,11 +380,13 @@ namespace ASFui
             {
                 if (!tbInput.Text.Equals(""))
                 {
-                    sendCommand(Util.GenerateCommand("ownsall", string.Empty, Util.MultiToOne(tbInput.Lines)));
+                    var status = sendCommand(Util.GenerateCommand("owns ASF", string.Empty, Util.MultiToOne(tbInput.Lines)));
+                    if ("Couldn't find any bot named ASF!".Equals(status))
+                        status = sendCommand(Util.GenerateCommand("ownsall", string.Empty, Util.MultiToOne(tbInput.Lines))); // keep backwardscompatibility
                 }
                 else
                 {
-                    Logging.Error(@"Input required (!ownsall)");
+                    Logging.Error(@"Input required (!owns ASF)");
                     MessageBox.Show(@"An input is required.", @"Input required", MessageBoxButtons.OK,
                         MessageBoxIcon.Error);
                 }
@@ -411,8 +418,10 @@ namespace ASFui
 
         private void btnStartAll_Click(object sender, EventArgs e)
         {
-            sendCommand("startall");
-            GetBotList();
+            var status = sendCommand("start ASF");
+            if ("Couldn't find any bot named ASF!".Equals(status))
+                status = sendCommand("startall"); // keep backwardscompatibility
+            //GetBotList();
         }
 
         private void btnStopBot_Click(object sender, EventArgs e)
@@ -447,7 +456,9 @@ namespace ASFui
 
         private void btnStatusAll_Click(object sender, EventArgs e)
         {
-            sendCommand("statusall");
+            var status = sendCommand("status ASF");
+            if ("Couldn't find any bot named ASF!".Equals(status))
+                status = sendCommand("statusall"); // keep backwardscompatibility
         }
 
         #endregion


### PR DESCRIPTION
Seems an error occurs, if Autorestart or SteamownerID are missing from the ASF.json.

Fixed it to silently ignore, if the value check for ASF.json is failing.

Added proper handling if values are missing as well.


fixing the XXAll buttons, keeping backwardscompatibility. Recommend GUI restructure with multi bot commands